### PR TITLE
add pretty flag for human readable output

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ cat query.sql | sql test_db
 sed 's/2015/2016/g' query_for_2015.sql | sql db1 db2 db3
 
 echo "SELECT * FROM users WHERE name = 'John'" | sql all
+
+# use 'pretty' flag, -p, if you need column names and do not need pipable output:
+echo "SELECT * from auth limit 1" | sql -p db1
 ```
 
 ## Notes

--- a/main.go
+++ b/main.go
@@ -21,9 +21,11 @@ type database struct {
 }
 
 var help = flag.Bool("help", false, "shows usage")
+var verbose = flag.Bool("verbose", false, "includes column names in output")
 
 func init() {
 	flag.BoolVar(help, "h", false, "shows usage")
+	flag.BoolVar(verbose, "v", false, "includes column names in output")
 }
 
 func main() {
@@ -45,6 +47,9 @@ func main() {
 
 	targetDatabases := []string{}
 	for _, k := range os.Args[1:] {
+		if k == "-v" || k == "--verbose" {
+			continue
+		}
 		if _, ok := databases[k]; k != "all" && !ok {
 			usage("Target database unknown: [%v]", k)
 		}
@@ -102,6 +107,9 @@ func runSQL(db database, sql string, key string, prependKey bool) bool {
 
 	mysql := "mysql"
 	options := fmt.Sprintf(" -Nsr %v%v%v%v -e ", userOption, passOption, hostOption, db.DbName)
+	if *verbose {
+		options = fmt.Sprintf(" -vt %v%v%v%v -e ", userOption, passOption, hostOption, db.DbName)
+	}
 
 	var cmd *exec.Cmd
 	if db.AppServer != "" {

--- a/main.go
+++ b/main.go
@@ -21,11 +21,11 @@ type database struct {
 }
 
 var help = flag.Bool("help", false, "shows usage")
-var verbose = flag.Bool("verbose", false, "includes column names in output")
+var pretty = flag.Bool("pretty", false, "includes column names in output")
 
 func init() {
 	flag.BoolVar(help, "h", false, "shows usage")
-	flag.BoolVar(verbose, "v", false, "includes column names in output")
+	flag.BoolVar(pretty, "p", false, "includes column names in output")
 }
 
 func main() {
@@ -47,7 +47,7 @@ func main() {
 
 	targetDatabases := []string{}
 	for _, k := range os.Args[1:] {
-		if k == "-v" || k == "--verbose" {
+		if k == "-p" || k == "--pretty" {
 			continue
 		}
 		if _, ok := databases[k]; k != "all" && !ok {
@@ -107,7 +107,7 @@ func runSQL(db database, sql string, key string, prependKey bool) bool {
 
 	mysql := "mysql"
 	options := fmt.Sprintf(" -Nsr %v%v%v%v -e ", userOption, passOption, hostOption, db.DbName)
-	if *verbose {
+	if *pretty {
 		options = fmt.Sprintf(" -vt %v%v%v%v -e ", userOption, passOption, hostOption, db.DbName)
 	}
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ var (
 )
 
 func main() {
+	flag.BoolVar(help, "help", false, "shows usage")
 	flag.BoolVar(help, "h", false, "shows usage")
 	flag.BoolVar(pretty, "p", false, "includes column names in output")
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -23,17 +23,17 @@ type database struct {
 	Pass      string
 }
 
-var help = flag.Bool("help", false, "shows usage")
-var pretty = flag.Bool("pretty", false, "includes column names in output")
-var printLock sync.Mutex
-
-func init() {
-	flag.BoolVar(help, "h", false, "shows usage")
-	flag.BoolVar(pretty, "p", false, "includes column names in output")
-}
+var (
+	help      = new(bool)
+	pretty    = new(bool)
+	printLock sync.Mutex
+)
 
 func main() {
+	flag.BoolVar(help, "h", false, "shows usage")
+	flag.BoolVar(pretty, "p", false, "includes column names in output")
 	flag.Parse()
+
 	if *help {
 		usage("")
 	}

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	targetDatabases := []string{}
 	for _, k := range os.Args[1:] {
-		if k == "-p" || k == "--pretty" {
+		if k == "-p" {
 			continue
 		}
 		if _, ok := databases[k]; k != "all" && !ok {

--- a/usage.go
+++ b/usage.go
@@ -15,13 +15,26 @@ func usage(error string, args ...interface{}) {
 		fmt.Println()
 	}
 
-	fmt.Println(`usage: ... | sql target_1 [target_2 ...]
+	fmt.Println(`sql usage:
+  anything | sql [-v] target_1
+  anything | sql target_1 [target_2...]
+  anything | sql all
 
-e.g.
+By default, no column names are output.
+Querying one target outputs one line per result row, in TSV/tab separated value format.
+Querying multiple targets outputs one line per target per result row as TSV rows, prepended with [target_name\t].
+Querying "all" targets every configured database.
+
+The -v flag modifies the output to include +--+ separators and column names.
+Using -v with multiple targets is not advised.
+
+Examples:
 
   cat query.sql | sql test_db
 
   sed 's/2015/2016/g' query_for_2015.sql | sql db1 db2 db3
+
+  echo "SELECT * FROM users LIMIT 1\G" | sql -v db1
 
   echo "SELECT * FROM users WHERE name = 'John'" | sql all
 

--- a/usage.go
+++ b/usage.go
@@ -16,17 +16,17 @@ func usage(error string, args ...interface{}) {
 	}
 
 	fmt.Println(`sql usage:
-  anything | sql [-v] target_1
+  anything | sql [-p] target_1
   anything | sql target_1 [target_2...]
   anything | sql all
 
 By default, no column names are output.
-Querying one target outputs one line per result row, in TSV/tab separated value format.
-Querying multiple targets outputs one line per target per result row as TSV rows, prepended with [target_name\t].
+Querying one target outputs one line per result row, as tab separated values.
+Querying multiple targets outputs one line per target per result row, as TSV, prepended with [target_name\t].
 Querying "all" targets every configured database.
 
-The -v flag modifies the output to include +--+ separators and column names.
-Using -v with multiple targets is not advised.
+The --pretty | -p flag modifies the output to include +--+ separators and column names for human readability.
+Using -p with multiple targets is not advised.
 
 Examples:
 
@@ -34,7 +34,7 @@ Examples:
 
   sed 's/2015/2016/g' query_for_2015.sql | sql db1 db2 db3
 
-  echo "SELECT * FROM users LIMIT 1\G" | sql -v db1
+  echo "SELECT * FROM users LIMIT 1\G" | sql -p db1
 
   echo "SELECT * FROM users WHERE name = 'John'" | sql all
 

--- a/usage.go
+++ b/usage.go
@@ -20,23 +20,23 @@ func usage(error string, args ...interface{}) {
   anything | sql target_1 [target_2...]
   anything | sql all
 
+target_1, target_2 etc must be defined in $HOME/.databases.json
+
 By default, no column names are output.
 Querying one target outputs one line per result row, as tab separated values.
-Querying multiple targets outputs one line per target per result row, as TSV, prepended with [target_name\t].
+Querying multiple targets outputs one line per target per result row, as TSV, prepended with target_name.
 Querying "all" targets every configured database.
 
-The --pretty | -p flag modifies the output to include +--+ separators and column names for human readability.
+The 'pretty' flag, -p, modifies the output to include +--+ separators and column names for human readability.
 Using -p with multiple targets is not advised.
 
 Examples:
 
   cat query.sql | sql test_db
-
-  sed 's/2015/2016/g' query_for_2015.sql | sql db1 db2 db3
-
-  echo "SELECT * FROM users LIMIT 1\G" | sql -p db1
-
   echo "SELECT * FROM users WHERE name = 'John'" | sql all
+  sed 's/2015/2016/g' query_for_2015.sql | sql db1 db2 db3
+  echo "SELECT * FROM users LIMIT 1" | sql -p db1
+  echo "SELECT * FROM users LIMIT 1\G" | sql -p db1
 
 For more detailed help, please go to: https://github.com/marianogappa/sql
 `)


### PR DESCRIPTION
I understand this was built as a piping tool, but I find myself frequently using it for manual queries. It fails in one scenario: where I am not familiar with a large table and want to inspect a complete record (i.e. I do not know what columns I want.)

This PR adds a `-p` flag that modifies the output from a pipable format to a human-readable format that includes column names:

```
 ⎇ add-verbose-flag marianogappa/sql Ω echo "select 9 as fingers" | sql demo
9

 ⎇ add-verbose-flag marianogappa/sql Ω echo "select 9 as fingers\G" | sql demo
*************************** 1. row ***************************
9

 ⎇ add-verbose-flag marianogappa/sql Ω echo "select 9 as fingers" | sql -v demo
--------------
select 9 as fingers
--------------

+---------+
| fingers |
+---------+
|       9 |
+---------+

 ⎇ add-verbose-flag marianogappa/sql Ω echo "select 9 as fingers\G" | sql -v demo
--------------
select 9 as fingers
--------------

*************************** 1. row ***************************
fingers: 9

```