### PR TITLE
mysql: output vertical format when query ends in \G

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -81,6 +81,19 @@ var baseTests = tests{
 	},
 }
 
+var mysqlTests = tests{{
+	name:      `mysql outputs vertical with \G`,
+	targetDBs: []string{"db1"},
+	query:     `SELECT id, name FROM table1 order by id asc limit 1\G`,
+	expected: []string{
+		"",
+		"*************************** 1. row ***************************",
+		"id: 1",
+		"name: John",
+	},
+},
+}
+
 func Test_MySQL(t *testing.T) {
 	awaitDB(mySQL, t)
 
@@ -92,6 +105,7 @@ func Test_MySQL(t *testing.T) {
 		}
 	)
 	runTests(baseTests, testConfig, t)
+	runTests(mysqlTests, testConfig, t)
 }
 
 func Test_PostgreSQL(t *testing.T) {


### PR DESCRIPTION
I need the output to include column names when I am learning the structure of a db. This PR produces  similar output as #8, but is triggered by ending your query in `\G`.

```
 ⎇ respect-da-g marianogappa/sql Ω sql mydb <<< "select 1 as a, 'foo' as b"                   
1       foo
 ⎇ respect-da-g marianogappa/sql Ω sql mydb <<< "select 1 as a, 'foo' as b\G"
*************************** 1. row ***************************
a: 1
b: foo
```